### PR TITLE
Modified and Improved VS2010 Dark Settings

### DIFF
--- a/vs2010/solarized-dark.vssettings
+++ b/vs2010/solarized-dark.vssettings
@@ -8,16 +8,42 @@
 			<PropertyValue name="Version">2</PropertyValue>
 			<FontsAndColors Version="2.0">
 				<Categories>
-					<Category GUID="{A27B4E24-A735-4D1D-B8E7-9716E1E3D8E0}" FontIsDefault="Yes">
+					<Category GUID="{00CCEE86-3140-4E06-A65A-A92665A40D6F}" FontName="Consolas" FontSize="8" CharSet="0" FontIsDefault="No">
 						<Items>
-							<Item Name="Plain Text" Foreground="0x00A1A193" Background="0x00362B00" BoldFont="Yes"/>
+							<Item Name="Plain Text" Foreground="0x00969483" Background="0x00362B00" BoldFont="No"/>
+							<Item Name="Selected Text" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
+						</Items>
+					</Category>
+					<Category GUID="{5C48B2CB-0366-4FBF-9786-0BB37E945687}" FontName="Consolas" FontSize="8" CharSet="0" FontIsDefault="No">
+						<Items>
+							<Item Name="Plain Text" Foreground="0x00969483" Background="0x00362B00" BoldFont="No"/>
+							<Item Name="Selected Text" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
+							<Item Name="Current List Location" Foreground="0x00E3F6FD" Background="0x00D28B26" BoldFont="No"/>
+						</Items>
+					</Category>
+					<Category GUID="{6BB65C5A-2F31-4BDE-9F48-8A38DC0C63E7}" FontName="Consolas" FontSize="8" CharSet="0" FontIsDefault="No">
+						<Items>
+							<Item Name="Plain Text" Foreground="0x00969483" Background="0x00362B00" BoldFont="No"/>
+							<Item Name="Selected Text" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
+						</Items>
+					</Category>
+					<Category GUID="{9973EFDF-317D-431C-8BC1-5E88CBFD4F7F}" FontName="Consolas" FontSize="8" CharSet="0" FontIsDefault="No">
+						<Items>
+							<Item Name="Plain Text" Foreground="0x00969483" Background="0x00362B00" BoldFont="No"/>
+							<Item Name="Selected Text" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
+							<Item Name="Current List Location" Foreground="0x00E3F6FD" Background="0x00423607" BoldFont="No"/>
+						</Items>
+					</Category>
+					<Category GUID="{A27B4E24-A735-4D1D-B8E7-9716E1E3D8E0}" FontName="Consolas" FontSize="8" CharSet="0" FontIsDefault="No">
+						<Items>
+							<Item Name="Plain Text" Foreground="0x00A1A193" Background="0x00362B00" BoldFont="No"/>
 							<Item Name="Selected Text" Foreground="0x00837B65" Background="0x00D5E8EE" BoldFont="No"/>
 							<Item Name="Inactive Selected Text" Foreground="0x00969483" Background="0x00423607" BoldFont="No"/>
-							<Item Name="Indicator Margin" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+							<Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
 							<Item Name="Line Numbers" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
 							<Item Name="Visible White Space" Foreground="0x00423607" Background="0x02000000" BoldFont="No"/>
 							<Item Name="Bookmark" Foreground="0x0100000B" Background="0x00D5E8EE" BoldFont="No"/>
-							<Item Name="Brace Matching (Rectangle)" Foreground="0x02000000" Background="0x00D5E8EE" BoldFont="No"/>
+							<Item Name="Brace Matching (Rectangle)" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
 							<Item Name="Breakpoint (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
 							<Item Name="Breakpoint (Enabled)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
 							<Item Name="Breakpoint (Error)" Foreground="0x00D5E8EE" Background="0x002F32DC" BoldFont="No"/>
@@ -31,11 +57,12 @@
 							<Item Name="Breakpoint - Mapped (Error)" Foreground="0x00D5E8EE" Background="0x002F32DC" BoldFont="No"/>
 							<Item Name="Breakpoint - Mapped (Warning)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
 							<Item Name="Breakpoint - Selected" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+							<Item Name="C/C++ User Keywords" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
 							<Item Name="Call Return" Foreground="0x00363000" Background="0x0098A12A" BoldFont="No"/>
-							<Item Name="Call Return New Context" Foreground="0x00423607" Background="0x0098A12A" BoldFont="No"/>
 							<Item Name="Code Snippet Dependent Field" Foreground="0x00D5E8EE" Background="0x02000000" BoldFont="No"/>
 							<Item Name="Code Snippet Field" Foreground="0x01000000" Background="0x00D5E8EE" BoldFont="No"/>
 							<Item Name="Collapsible Text" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
+							<Item Name="outlining.collapsehintadornment" Foreground="0x00E8DDD7" Background="0x02000000" BoldFont="No"/>
 							<Item Name="Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
 							<Item Name="Compiler Error" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
 							<Item Name="CSS Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
@@ -44,11 +71,12 @@
 							<Item Name="CSS Property Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
 							<Item Name="CSS Selector" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
 							<Item Name="CSS String Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-							<Item Name="Current list location" Foreground="0x00D5E8EE" Background="0x00D28B26" BoldFont="No"/>
+							<Item Name="Current List Location" Foreground="0x00D5E8EE" Background="0x00D28B26" BoldFont="No"/>
 							<Item Name="Definition Window Current Match" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-							<Item Name="Disassembly Symbol" Foreground="0x00C4716C" Background="0x02000000" BoldFont="No"/>
-							<Item Name="Excluded Code" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
-							<Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x00837B65" Background="0x00E3F6FD" BoldFont="No"/>
+							<Item Name="SourceLineClassificationFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+							<Item Name="SymbolLineClassificationFormat" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+							<Item Name="Excluded Code" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+							<Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
 							<Item Name="HTML Attribute" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
 							<Item Name="HTML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
 							<Item Name="HTML Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
@@ -58,13 +86,12 @@
 							<Item Name="HTML Server-Side Script" Foreground="0x008236D3" Background="0x00423607" BoldFont="No"/>
 							<Item Name="HTML Tag Delimiter" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
 							<Item Name="Identifier" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-							<Item Name="Keyword" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+							<Item Name="Keyword" Foreground="0x00009985" Background="0x02000000" BoldFont="Yes"/>
 							<Item Name="Memory Changed" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-							<Item Name="Number" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-							<Item Name="Operator" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
+							<Item Name="Number" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+							<Item Name="Operator" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
 							<Item Name="Other Error" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
 							<Item Name="Preprocessor Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-							<Item Name="Razor Code" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
 							<Item Name="Refactoring Background" Foreground="0x01000002" Background="0x00E3F6FD" BoldFont="No"/>
 							<Item Name="Refactoring Current Field" Foreground="0x01000000" Background="0x00D5E8EE" BoldFont="No"/>
 							<Item Name="Refactoring Dependent Field" Foreground="0x00D5E8EE" Background="0x02000000" BoldFont="No"/>
@@ -77,19 +104,20 @@
 							<Item Name="Smart Tag" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
 							<Item Name="SQL DML Marker" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
 							<Item Name="Stale Code" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
-							<Item Name="String" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-							<Item Name="String(C# @ Verbatim)" Foreground="0x0098A12A" Background="0x02000000" BoldFont="Yes"/>
+							<Item Name="String" Foreground="0x00D28B26" Background="0x02000000" BoldFont="Yes"/>
+							<Item Name="String(C# @ Verbatim)" Foreground="0x00D28B26" Background="0x02000000" BoldFont="Yes"/>
 							<Item Name="Syntax Error" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
 							<Item Name="Task List Shortcut" Foreground="0x00363000" Background="0x00D28B26" BoldFont="No"/>
+							<Item Name="Text" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
 							<Item Name="Track Changes after save" Foreground="0x02000000" Background="0x00009985" BoldFont="No"/>
 							<Item Name="Track Changes before save" Foreground="0x02000000" Background="0x000089B5" BoldFont="No"/>
+							<Item Name="urlformat" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
 							<Item Name="User Types" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
 							<Item Name="User Types(Delegates)" Foreground="0x00C4716C" Background="0x02000000" BoldFont="Yes"/>
 							<Item Name="User Types(Enums)" Foreground="0x00C4716C" Background="0x02000000" BoldFont="Yes"/>
 							<Item Name="User Types(Interfaces)" Foreground="0x008236D3" Background="0x02000000" BoldFont="Yes"/>
 							<Item Name="User Types(Value types)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
 							<Item Name="Warning" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-							<Item Name="Warning Lines Path" Foreground="0x00A50000" Background="0x00E6EFEE" BoldFont="No"/>
 							<Item Name="XAML Attribute" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
 							<Item Name="XAML Attribute Quotes" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
 							<Item Name="XAML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
@@ -106,17 +134,29 @@
 							<Item Name="XML Attribute" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
 							<Item Name="XML Attribute Quotes" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
 							<Item Name="XML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-							<Item Name="XML CData Section" Foreground="0x00969483" Background="0x00423607" BoldFont="No"/>
+							<Item Name="XML CData Section" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
 							<Item Name="XML Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
 							<Item Name="XML Delimiter" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
-							<Item Name="XML Doc Attribute" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
-							<Item Name="XML Doc Comment" Foreground="0x00756E58" Background="0x00423607" BoldFont="Yes"/>
-							<Item Name="XML Doc Tag" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
+							<Item Name="XML Doc Attribute" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+							<Item Name="XML Doc Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="Yes"/>
+							<Item Name="XML Doc Tag" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
 							<Item Name="XML Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
 							<Item Name="XML Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="Yes"/>
 							<Item Name="XML Processing Instruction" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
 							<Item Name="XML Text" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
 							<Item Name="XSLT Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+						</Items>
+					</Category>
+					<Category GUID="{A9A5637F-B2A8-422E-8FB5-DFB4625F0111}" FontName="Consolas" FontSize="8" CharSet="1" FontIsDefault="No">
+						<Items/>
+					</Category>
+					<Category GUID="{AD3737CA-26A1-47CB-A143-0EB0ECBC7FC9}" FontName="Consolas" FontSize="8" CharSet="1" FontIsDefault="No">
+						<Items/>
+					</Category>
+					<Category GUID="{EE1BE240-4E81-4BEB-8EEA-54322B6B1BF5}" FontName="Consolas" FontSize="8" CharSet="0" FontIsDefault="No">
+						<Items>
+							<Item Name="Plain Text" Foreground="0x00969483" Background="0x00362B00" BoldFont="No"/>
+							<Item Name="Selected Text" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
 						</Items>
 					</Category>
 				</Categories>


### PR DESCRIPTION
Hey @leddt,

I made some changes to the vs2010 dark settings to further the solarized colour integration with other text editors inside Visual Studio. See my commit notes below:

Modified VS2010 dark settings to fix URL colours, and altered strings, numbers, operators.
Fixed brace matching colours.
Modified for all text editor windows to match Solarized colours, including the Output window
Fixed XML comment background highlighting.

Please have a look and let me know if you like the changes.
