### PR TITLE
Added support for NuGet Package Manager Console

### DIFF
--- a/vs11/generator/SettingsTemplate.xml
+++ b/vs11/generator/SettingsTemplate.xml
@@ -123,6 +123,14 @@
 							<Item Name="vsvim_commandmargin" Foreground="$PrimaryContent" Background="$Background" BoldFont="No"/>
             </Items>
           </Category>
+					<!-- NuGet Package Manager Console -->
+					<Category GUID="{F9D6BCE6-C669-41DB-8EE7-DD953828685B}" FontIsDefault="Yes">
+						<Items>
+							<Item Name="Plain Text" Foreground="$PrimaryContent" Background="$Background" BoldFont="No"/>
+              <Item Name="Selected Text" Foreground="$PrimaryContent" Background="$SecondaryContent" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Foreground="$PrimaryContent" Background="$SecondaryContent" BoldFont="No"/>
+						</Items>
+					</Category>
         </Categories>
       </FontsAndColors>
     </Category>

--- a/vs11/solarized-dark.vssettings
+++ b/vs11/solarized-dark.vssettings
@@ -123,6 +123,14 @@
 							<Item Name="vsvim_commandmargin" Foreground="0x00969483" Background="0x00362B00" BoldFont="No"/>
             </Items>
           </Category>
+					<!-- NuGet Package Manager Console -->
+					<Category GUID="{F9D6BCE6-C669-41DB-8EE7-DD953828685B}" FontIsDefault="Yes">
+						<Items>
+							<Item Name="Plain Text" Foreground="0x00969483" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="Selected Text" Foreground="0x00969483" Background="0x00586E75" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Foreground="0x00969483" Background="0x00586E75" BoldFont="No"/>
+						</Items>
+					</Category>
         </Categories>
       </FontsAndColors>
     </Category>

--- a/vs11/solarized-light.vssettings
+++ b/vs11/solarized-light.vssettings
@@ -123,6 +123,14 @@
 							<Item Name="vsvim_commandmargin" Foreground="0x00837B65" Background="0x00E3F6FD" BoldFont="No"/>
             </Items>
           </Category>
+					<!-- NuGet Package Manager Console -->
+					<Category GUID="{F9D6BCE6-C669-41DB-8EE7-DD953828685B}" FontIsDefault="Yes">
+						<Items>
+							<Item Name="Plain Text" Foreground="0x00837B65" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="Selected Text" Foreground="0x00837B65" Background="0x00A1A193" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Foreground="0x00837B65" Background="0x00A1A193" BoldFont="No"/>
+						</Items>
+					</Category>
         </Categories>
       </FontsAndColors>
     </Category>


### PR DESCRIPTION
In VS11 the package manager console is now built-in, and uses its own color categories. This change adds the correct values for that toolwindow.
