### PR TITLE
Slightly simplify install

### DIFF
--- a/README
+++ b/README
@@ -4,8 +4,7 @@ Either clone the repository and use the vssettings files on your computer, or:
 
 1. On github, find the vssettings file that you want to use, and left click on it to open it.
 2. Find the "Raw" button in the top left toolbar.
-3. Right-click it and choose "Save as..."
-4. Save it to a convenient location.
+3. Right-click it and choose "Copy link address" to put the raw url in your clipboard
 
 To install:
 
@@ -14,6 +13,6 @@ To install:
 3. Select "Import selected environment settings"
 4. Backup if desired.
 5. Click "Browse".
-6. Locate solarized vssettings file.
+6. Paste in the url to the vssettings file.
 7. Click "Next".
 8. Done.


### PR DESCRIPTION
The file chooser dialog (and the Windows shell support) includes 
the ability to specify url's for files - this keeps the user from 
having to specifically save the file and then remember its location.
