### PR TITLE
Add C++ fields for VS2012

### DIFF
--- a/vs2012/generator/SettingsTemplate.xml
+++ b/vs2012/generator/SettingsTemplate.xml
@@ -40,6 +40,7 @@
               <Item Name="Compiler Error" Foreground="$Blue" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppMacroSemanticTokenFormat" Foreground="$PrimaryContent" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppEnumSemanticTokenFormat" Foreground="$Yellow" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="$PrimaryContent" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="$PrimaryContent" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppParameterSemanticTokenFormat" Foreground="$PrimaryContent" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppTypeSemanticTokenFormat" Foreground="$Yellow" Background="0x02000000" BoldFont="No"/>

--- a/vs2012/solarized-dark.vssettings
+++ b/vs2012/solarized-dark.vssettings
@@ -40,6 +40,7 @@
               <Item Name="Compiler Error" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppMacroSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppEnumSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>

--- a/vs2012/solarized-light.vssettings
+++ b/vs2012/solarized-light.vssettings
@@ -40,6 +40,7 @@
               <Item Name="Compiler Error" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppMacroSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppEnumSemanticTokenFormat" Foreground="0x000089b5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
               <Item Name="CppTypeSemanticTokenFormat" Foreground="0x000089b5" Background="0x02000000" BoldFont="No"/>


### PR DESCRIPTION
I went ahead and added the required C++ fields for VS2012.  My changes use the standard colors, and don't mess with the existing settings at all.

This should address issues #23 and #24.
