### PR TITLE
VS2017 Fixes

### DIFF
--- a/vs2017/generator/SettingsTemplate.xml
+++ b/vs2017/generator/SettingsTemplate.xml
@@ -102,7 +102,7 @@
               <Item Name="SQL DML Marker" Foreground="$Blue" Background="0x02000000" BoldFont="No"/>
               <Item Name="Stale Code" Foreground="$Magenta" Background="0x02000000" BoldFont="No"/>
               <Item Name="String" Foreground="$Cyan" Background="0x02000000" BoldFont="No"/>
-              <Item Name="String(C# @ Verbatim)" Foreground="$Cyan" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="string - verbatim" Foreground="$Cyan" Background="0x02000000" BoldFont="Yes"/>
               <Item Name="Syntax Error" Foreground="$Red" Background="0x02000000" BoldFont="No"/>
               <Item Name="Task List Shortcut" Foreground="$Background" Background="$Blue" BoldFont="No"/>
               <Item Name="Track Changes after save" Foreground="0x02000000" Background="$Green" BoldFont="No"/>

--- a/vs2017/generator/SettingsTemplate.xml
+++ b/vs2017/generator/SettingsTemplate.xml
@@ -87,6 +87,7 @@
               <Item Name="Operator" Foreground="$Green" Background="0x02000000" BoldFont="No"/>
               <Item Name="Other Error" Foreground="$Magenta" Background="0x02000000" BoldFont="No"/>
               <Item Name="Preprocessor Keyword" Foreground="$Orange" Background="0x02000000" BoldFont="No"/>
+              <Item Name="punctuation" Foreground="$PrimaryContent" Background="0x02000000" BoldFont="No"/>
               <Item Name="Razor Code" Foreground="0x02000000" Background="$BgHighlight" BoldFont="No"/>
               <Item Name="Refactoring Background" Foreground="0x01000002" Background="$Highlight2" BoldFont="No"/>
               <Item Name="Refactoring Current Field" Foreground="0x01000000" Background="$Highlight1" BoldFont="No"/>

--- a/vs2017/generator/SettingsTemplate.xml
+++ b/vs2017/generator/SettingsTemplate.xml
@@ -112,6 +112,7 @@
               <Item Name="User Types(Enums)" Foreground="$Yellow" Background="0x02000000" BoldFont="Yes"/>
               <Item Name="User Types(Interfaces)" Foreground="$Yellow" Background="0x02000000" BoldFont="Yes"/>
               <Item Name="User Types(Value types)" Foreground="$Yellow" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="urlformat" Foreground="$Blue" Background="0x02000000" BoldFont="No"/>
               <Item Name="module name" Foreground="$Yellow" Background="0x02000000" BoldFont="No"/>
               <Item Name="interface name" Foreground="$Yellow" Background="0x02000000" BoldFont="Yes"/>
               <Item Name="enum name" Foreground="$Yellow" Background="0x02000000" BoldFont="Yes"/>

--- a/vs2017/solarized-dark.vssettings
+++ b/vs2017/solarized-dark.vssettings
@@ -87,6 +87,7 @@
               <Item Name="Operator" Foreground="0x00079A71" Background="0x02000000" BoldFont="No"/>
               <Item Name="Other Error" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
               <Item Name="Preprocessor Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="punctuation" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
               <Item Name="Razor Code" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
               <Item Name="Refactoring Background" Foreground="0x01000002" Background="0x00E3F6FD" BoldFont="No"/>
               <Item Name="Refactoring Current Field" Foreground="0x01000000" Background="0x00D5E8EE" BoldFont="No"/>
@@ -101,7 +102,7 @@
               <Item Name="SQL DML Marker" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
               <Item Name="Stale Code" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
               <Item Name="String" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="String(C# @ Verbatim)" Foreground="0x0098A12A" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="string - verbatim" Foreground="0x0098A12A" Background="0x02000000" BoldFont="Yes"/>
               <Item Name="Syntax Error" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
               <Item Name="Task List Shortcut" Foreground="0x00362B00" Background="0x00D28B26" BoldFont="No"/>
               <Item Name="Track Changes after save" Foreground="0x02000000" Background="0x00079A71" BoldFont="No"/>
@@ -111,6 +112,7 @@
               <Item Name="User Types(Enums)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
               <Item Name="User Types(Interfaces)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
               <Item Name="User Types(Value types)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="urlformat" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
               <Item Name="module name" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
               <Item Name="interface name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
               <Item Name="enum name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>

--- a/vs2017/solarized-light.vssettings
+++ b/vs2017/solarized-light.vssettings
@@ -87,6 +87,7 @@
               <Item Name="Operator" Foreground="0x00079A71" Background="0x02000000" BoldFont="No"/>
               <Item Name="Other Error" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
               <Item Name="Preprocessor Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="punctuation" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
               <Item Name="Razor Code" Foreground="0x02000000" Background="0x00D5E8EE" BoldFont="No"/>
               <Item Name="Refactoring Background" Foreground="0x01000002" Background="0x00362B00" BoldFont="No"/>
               <Item Name="Refactoring Current Field" Foreground="0x01000000" Background="0x00423607" BoldFont="No"/>
@@ -101,7 +102,7 @@
               <Item Name="SQL DML Marker" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
               <Item Name="Stale Code" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
               <Item Name="String" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="String(C# @ Verbatim)" Foreground="0x0098A12A" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="string - verbatim" Foreground="0x0098A12A" Background="0x02000000" BoldFont="Yes"/>
               <Item Name="Syntax Error" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
               <Item Name="Task List Shortcut" Foreground="0x00E3F6FD" Background="0x00D28B26" BoldFont="No"/>
               <Item Name="Track Changes after save" Foreground="0x02000000" Background="0x00079A71" BoldFont="No"/>
@@ -111,6 +112,7 @@
               <Item Name="User Types(Enums)" Foreground="0x000089b5" Background="0x02000000" BoldFont="Yes"/>
               <Item Name="User Types(Interfaces)" Foreground="0x000089b5" Background="0x02000000" BoldFont="Yes"/>
               <Item Name="User Types(Value types)" Foreground="0x000089b5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="urlformat" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
               <Item Name="module name" Foreground="0x000089b5" Background="0x02000000" BoldFont="No"/>
               <Item Name="interface name" Foreground="0x000089b5" Background="0x02000000" BoldFont="Yes"/>
               <Item Name="enum name" Foreground="0x000089b5" Background="0x02000000" BoldFont="Yes"/>


### PR DESCRIPTION
Fixes a few random issues with the VS2017 styles:

- Punctuation characters weren't being styled. Same as what was going on in #31 for VS2015.
- Verbatim `@"strings"` weren't being styled; name of the style was wrong.
- URLs weren't being styled and were pretty hard to read particularly in dark.

Dark before:
![dark-before](https://user-images.githubusercontent.com/8688316/27348346-b70fdff4-55c1-11e7-9721-d145bc492db6.png)

Dark after:
![dark-after](https://user-images.githubusercontent.com/8688316/27348348-b7118f16-55c1-11e7-8e77-e85a514794b6.png)

Light before:
![light-before](https://user-images.githubusercontent.com/8688316/27348347-b7107054-55c1-11e7-8f9b-838b25cbf0d4.png)

Light after:
![light-after](https://user-images.githubusercontent.com/8688316/27348349-b7143496-55c1-11e7-993c-c73b83cd8913.png)
