### PR TITLE
Fix typo in Razor Code tag name

### DIFF
--- a/vs2017/generator/SettingsTemplate.xml
+++ b/vs2017/generator/SettingsTemplate.xml
@@ -88,7 +88,7 @@
               <Item Name="Other Error" Foreground="$Magenta" Background="0x02000000" BoldFont="No"/>
               <Item Name="Preprocessor Keyword" Foreground="$Orange" Background="0x02000000" BoldFont="No"/>
               <Item Name="punctuation" Foreground="$PrimaryContent" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Razor Code" Foreground="0x02000000" Background="$BgHighlight" BoldFont="No"/>
+              <Item Name="RazorCode" Foreground="0x02000000" Background="$BgHighlight" BoldFont="No"/>
               <Item Name="Refactoring Background" Foreground="0x01000002" Background="$Highlight2" BoldFont="No"/>
               <Item Name="Refactoring Current Field" Foreground="0x01000000" Background="$Highlight1" BoldFont="No"/>
               <Item Name="Refactoring Dependent Field" Foreground="$Highlight1" Background="0x02000000" BoldFont="No"/>

--- a/vs2017/solarized-dark.vssettings
+++ b/vs2017/solarized-dark.vssettings
@@ -88,7 +88,7 @@
               <Item Name="Other Error" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
               <Item Name="Preprocessor Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
               <Item Name="punctuation" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Razor Code" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
+              <Item Name="RazorCode" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
               <Item Name="Refactoring Background" Foreground="0x01000002" Background="0x00E3F6FD" BoldFont="No"/>
               <Item Name="Refactoring Current Field" Foreground="0x01000000" Background="0x00D5E8EE" BoldFont="No"/>
               <Item Name="Refactoring Dependent Field" Foreground="0x00D5E8EE" Background="0x02000000" BoldFont="No"/>

--- a/vs2017/solarized-light.vssettings
+++ b/vs2017/solarized-light.vssettings
@@ -88,7 +88,7 @@
               <Item Name="Other Error" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
               <Item Name="Preprocessor Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
               <Item Name="punctuation" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Razor Code" Foreground="0x02000000" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="RazorCode" Foreground="0x02000000" Background="0x00D5E8EE" BoldFont="No"/>
               <Item Name="Refactoring Background" Foreground="0x01000002" Background="0x00362B00" BoldFont="No"/>
               <Item Name="Refactoring Current Field" Foreground="0x01000000" Background="0x00423607" BoldFont="No"/>
               <Item Name="Refactoring Dependent Field" Foreground="0x00423607" Background="0x02000000" BoldFont="No"/>


### PR DESCRIPTION
I found a typo in one of the tag names causing problems with `.cshtml`.

This is for VS2017, and this PR should resolve for both light & dark themes (though the issue was only really evident in the dark theme).